### PR TITLE
Bugfix/1 mobile nav header

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -20,8 +20,8 @@
   <body>
       <div id="header">
         <nav>
-          <li class="fork"><a href="/">Home</a></li>  
-          <li class="fork"><a href="/scanly">Talk to Scanly</a></li>
+          <li class="fork"><a {% if page.url == "/" %} class="active" {% endif %} href="/">Home</a></li>  
+          <li class="fork"><a {% if page.url == "/scanly/" %} class="active" {% endif %} href="/scanly/">Talk to Scanly</a></li>
           <li class="downloads"><a href="https://github.com/DuckDuckGroup/Scanly/tree/main" target="_blank">View On GitHub</a></li>
           {% if site.show_downloads %}
             <li class="downloads"><a href="{{ site.github.zip_url }}">ZIP</a></li>

--- a/_sass/jekyll-theme-midnight.scss
+++ b/_sass/jekyll-theme-midnight.scss
@@ -296,13 +296,13 @@ section {
 @media print, screen and (max-width: 480px) {
 
   #header {
-    margin-top: -20px;
+    margin-top: -2%;
   }
 
   section {
     margin-top: 40px;
   }
-  nav {
+  /*nav {
     display: none;
-  }
+  }*/
 }

--- a/_sass/jekyll-theme-midnight.scss
+++ b/_sass/jekyll-theme-midnight.scss
@@ -197,7 +197,7 @@ dt {
         display:inline-block;
         text-align:center;
 
-        &:hover {
+        &:hover, &.active {
           background: linear-gradient(#749619, #527f0e);
           background-color: #659e10;
           border: 1px solid #527f0e;

--- a/_sass/jekyll-theme-midnight.scss
+++ b/_sass/jekyll-theme-midnight.scss
@@ -293,16 +293,19 @@ section {
   }
 }
 
-@media print, screen and (max-width: 480px) {
+@media print, screen and (max-width: 340px) {
 
   #header {
-    margin-top: -2%;
+    margin-top: -10px;
   }
 
   section {
     margin-top: 40px;
   }
-  /*nav {
-    display: none;
-  }*/
+
+  #header nav li a {
+    font-size: 10px;
+    line-height: 10px;
+    padding: 5px 6px;
+  }
 }

--- a/scanly.md
+++ b/scanly.md
@@ -1,3 +1,7 @@
+---
+permalink: /scanly/
+layout: default
+---
 ## Scanly says Sorry!
 ### We're still building Scanly...
 However, you will be able to talk with them soon, as we aim to have a prototype ready before the start of December 2020.


### PR DESCRIPTION
Fixes relating to issue #2 
- Website is now responsive and able to support any screen size larger than 236px
- Navigation bar shrinks/re-sizes when screen size is below 340px
- Navigation bar now shows an active link for the current page you are on (this is the same as the hover state)

Future considerations:
- Is the shrinked down text (when screen size is less than 340px) too small?
- We will need to revisit this issue if we decide to add aditional navigation buttons to the menu, or add different text lengths to the current buttons!